### PR TITLE
Fix syndrome and symptom delete and update, enhance survey return

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -46,6 +46,6 @@ class MessagesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def message_params
-      params.require(:message).permit(:title, :warning_message, :go_to_hospital_message, :syndrome_id)
+      params.require(:message).permit(:title, :warning_message, :go_to_hospital_message, :syndrome_id, :symptom_id)
     end
 end

--- a/app/controllers/symptoms_controller.rb
+++ b/app/controllers/symptoms_controller.rb
@@ -36,6 +36,9 @@ class SymptomsController < ApplicationController
 
   # DELETE /symptoms/1
   def destroy
+    SyndromeSymptomPercentage.where(symptom:@symptom).each do |obj|
+      obj.destroy
+    end
     @symptom.destroy
   end
 

--- a/app/controllers/syndromes_controller.rb
+++ b/app/controllers/syndromes_controller.rb
@@ -32,7 +32,9 @@ class SyndromesController < ApplicationController
   def update
     @symptoms = syndrome_params[:symptom]
     if @syndrome.update(syndrome_params.except(:symptom))
-      update_symptoms_and_connections
+      if !syndrome_params[:symptom].nil?
+        update_symptoms_and_connections
+      end
       render json: @syndrome
     else
       render json: @syndrome.errors, status: :unprocessable_entity
@@ -81,7 +83,6 @@ class SyndromesController < ApplicationController
             symptom: created_symptom,
             syndrome: @syndrome
           )
-          created_symptom.syndrome_symptom_percentage = syndrome_symptom_percentage
         end
       end
     end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -28,12 +28,20 @@ class Survey < ApplicationRecord
         @user_symptoms.append(Symptom.where(:description=>symptom)[0])
       end
     }
+    symptoms_and_syndromes_data = {}
+    symptom_messages = get_symptoms_messages
+    if symptom_messages.any?
+      symptoms_and_syndromes_data[:symptom_messages] = symptom_messages
+    end
     top_3 = get_top_3_syndromes
-    return {
-      :top_3 => top_3.map { |obj| { name: obj[:syndrome].description, percentage: obj[:likelyhood] }},
-      :top_syndrome_message => get_top_3_syndromes[0][:syndrome].message || '',
-      :symptom_messages => get_symptoms_messages
-    }
+    if top_3.any?
+      symptoms_and_syndromes_data[:top_3] = top_3.map { |obj| { name: obj[:syndrome].description, percentage: obj[:likelyhood] }}
+      syndrome_message = top_3[0][:syndrome].message
+      if !syndrome_message.nil?
+        symptoms_and_syndromes_data[:top_syndrome_message] = syndrome_message || ''
+      end
+    end
+    return symptoms_and_syndromes_data
   end
  
   scope :filter_by_user, ->(user) { where(user_id: user) }
@@ -51,6 +59,7 @@ class Survey < ApplicationRecord
       syndrome_list.append(new_syndrome)
     end
     syndrome_list = syndrome_list.sort_by { |syndrome| syndrome[:likelyhood] }.reverse
+    syndrome_list = syndrome_list.select { |syndrome| syndrome[:likelyhood] > 0 }
     return syndrome_list[0..2]
   end
 

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -2,10 +2,9 @@ class Symptom < ApplicationRecord
   belongs_to :app
   searchkick
 
-  has_one :message
+  has_one :message, dependent: :destroy
   accepts_nested_attributes_for :message
  
-  has_one :syndrome_symptom_percentage 
   scope :filter_symptom_by_app_id, ->(current_user_app_id) { where(app_id: current_user_app_id) }
 end
  

--- a/app/models/syndrome.rb
+++ b/app/models/syndrome.rb
@@ -1,7 +1,9 @@
 class Syndrome < ApplicationRecord
-    has_one :message
+    searchkick
+
+    has_one :message, dependent: :destroy
     accepts_nested_attributes_for :message
 
-    has_many :syndrome_symptom_percentage, :class_name => 'SyndromeSymptomPercentage'
+    has_many :syndrome_symptom_percentage, :class_name => 'SyndromeSymptomPercentage', dependent: :destroy
     has_many :symptoms, :through => :syndrome_symptom_percentage 
 end

--- a/app/serializers/symptom_serializer.rb
+++ b/app/serializers/symptom_serializer.rb
@@ -1,4 +1,4 @@
 class SymptomSerializer < ActiveModel::Serializer
-  attributes :id, :description, :code, :priority, :details
+  attributes :id, :description, :code, :priority, :details, :message
   has_one :app
 end


### PR DESCRIPTION
**Descrição**<br>

Conserta problemas que atrapalhavam o update e delete de sindromes e sintomas, da issue #[96](https://github.com/proepidesenvolvimento/guardioes-api/issues/96).

Melhora o retorno para as surveys de forma a faze-lo mais fácil de se usar no front-end, sem preprocessamento, associado a issue #98.

**Checklist**
- [x] Código compila corretamente
- [x] Mudanças realizadas foram testadas e passaram no testes
- [x] Feito por conta própria
