### PR TITLE
Add household count to users

### DIFF
--- a/app/controllers/households_controller.rb
+++ b/app/controllers/households_controller.rb
@@ -20,6 +20,7 @@ class HouseholdsController < ApplicationController
     @household.user_id = @user.id
 
     if @household.save
+      @user.update_household_count
       render json: @household, status: :created, location: user_household_path(:id => @user)
     else
       render json: @household.errors, status: :unprocessable_entity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,10 @@ class User < ApplicationRecord
     },
     format: { with: URI::MailTo::EMAIL_REGEXP, message: I18n.translate("validations.email.message") },
     uniqueness: true
+
+  attribute :household_count, :integer, default: 0
+
+  def update_household_count
+    self.update_attribute(:household_count, self.households.count)
+  end
 end

--- a/db/migrate/20200708192801_add_householdcount_to_user.rb
+++ b/db/migrate/20200708192801_add_householdcount_to_user.rb
@@ -1,0 +1,5 @@
+class AddHouseholdcountToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :household_count, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2020_07_08_192801) do
 
-ActiveRecord::Schema.define(version: 2020_07_01_225022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -237,6 +237,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_225022) do
     t.boolean "risk_group"
     t.string "aux_code"
     t.bigint "school_unit_id"
+    t.integer "household_count"
     t.index ["app_id"], name: "index_users_on_app_id"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
**Descrição**<br>

Para analisar q quantidade de households (parentes) que um usuário tem pelo kibana, a solução mais simples e eficiente é adicionar o dado nesta API. O mudança adiciona um campo chamado `household_count` que é guardado e `users` e é definido como 0 quando um usuário novo é criado. Adiciona também uma função que realiza um update nos usuários já existentes para consertar o dado. Essa função também é chamada na criação de um novo household.

**Checklist**
- [x] Código compila corretamente
- [x] Mudanças realizadas foram testadas e passaram no testes
- [x] Feito por conta própria
