### PR TITLE
Add user type select to content index

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,11 +1,15 @@
 class ContentsController < ApplicationController
-  before_action :authenticate_user!, only: [:index]
   before_action :authenticate_admin!, only: [:create, :destroy, :update]
   before_action :set_content, only: [:show, :update, :destroy]
 
   # GET /contents
   def index
-    @contents = Content.user_country(current_user.app_id)
+    if current_user.nil?
+      user = current_admin
+    else
+      user = current_user
+    end
+    @contents = Content.user_country(user.app_id)
 
     render json: @contents
   end


### PR DESCRIPTION
**Descrição**<br>
No método de index para conteudos tem uma validação que restringe a apenas User terem acesso ao endpoint e quando formos fazer uso disso no Painel de controle precisamos de que os Admins também tenham acesso por isso fiz com que o index seja renderizado para os dois ;<br>


**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
