### PR TITLE
Adding privacy policy version and created_at date to User object

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -139,7 +139,7 @@ private
   end
   # Only allow a trusted parameter "white list" through.
   def user_params
-    params.require(:user).permit(:user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :app_id, :password, :picture, :city, :identification_code, :state, :group_id, :risk_group)
+    params.require(:user).permit(:user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :app_id, :password, :picture, :city, :identification_code, :state, :group_id, :risk_group, :policy_version)
   end
 
   def update_params
@@ -155,8 +155,9 @@ private
       :city,
       :identification_code,
       :school_unit_id,
+      :group_id,
       :risk_group,
-      :group_id
+      :policy_version
     )
   end
 

--- a/app/serializers/household_serializer.rb
+++ b/app/serializers/household_serializer.rb
@@ -1,5 +1,5 @@
 class HouseholdSerializer < ActiveModel::Serializer
-  attributes :id, :description, :birthdate, :country, :gender, :race, :kinship, :picture, :school_unit_id, :identification_code, :risk_group, :group, :group_id
+  attributes :id, :description, :birthdate, :country, :gender, :race, :kinship, :picture, :school_unit_id, :identification_code, :group, :group_id, :risk_group, :created_at
   has_one :user
 
   def group

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :picture, :app_id, :city, :state, :identification_code, :group_id, :school_unit_id, :risk_group, :group
+  attributes :id, :user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :picture, :city, :state, :identification_code, :group_id, :school_unit_id, :risk_group, :group, :policy_version, :created_at
 
   belongs_to :app do
     link(:app) {app_url(object.app.id)}

--- a/db/migrate/20200901022156_add_policy_to_users.rb
+++ b/db/migrate/20200901022156_add_policy_to_users.rb
@@ -1,0 +1,5 @@
+class AddPolicyToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :policy_version, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_12_152255) do
+ActiveRecord::Schema.define(version: 2020_09_01_022156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -288,6 +288,7 @@ ActiveRecord::Schema.define(version: 2020_08_12_152255) do
     t.boolean "risk_group"
     t.string "aux_code"
     t.bigint "school_unit_id"
+    t.integer "policy_version", default: 1, null: false
     t.index ["app_id"], name: "index_users_on_app_id"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
**Descrição**<br>
Adiciona a coluna policy_version no user em formato inteiro (versão de compilação) para o manuseio do consentimento de termos e políticas do app. Também adiciona a data de criação do usuário e do household para facilitar e corrigir bugs nos cálculos da tela Diário do app.<br>

Corrige a issue: #149 . <br> 


**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
