### PR TITLE
Creates the feedback messages for consecutives reports

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -17,4 +17,3 @@ class AdminController < ApplicationController
       )
   end 
 end
-

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -46,6 +46,6 @@ class MessagesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def message_params
-      params.require(:message).permit(:title, :warning_message, :go_to_hospital_message, :syndrome_id, :symptom_id)
+      params.require(:message).permit(:title, :warning_message, :go_to_hospital_message, :syndrome_id, :symptom_id, :feedback_message)
     end
 end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -55,14 +55,23 @@ class SurveysController < ApplicationController
       render json: {errors: "The user already contributed with this survey today"}, status: :unprocessable_entity
     else
       if @survey.save
+        @user.update_streak(@survey)
         if @survey.symptom.length > 0
-          render json: { survey: @survey, messages: @survey.get_message }, status: :created, location: user_survey_path(:id => @user)
+          render json: { survey: @survey, feedback_message: @user.get_feedback_message ,messages: @survey.get_message }, status: :created, location: user_survey_path(:id => @user)
         else
-          render json: @survey, status: :created, location: user_survey_path(:id => @user)
+          render json: { survey: @survey, feedback_message: @user.get_feedback_message }, status: :created, location: user_survey_path(:id => @user)
         end
       else
         render json: @survey.errors, status: :unprocessable_entity
       end
+    end
+  end
+
+  def update
+    if @survey.update(params.require(:survey).permit(:created_at))
+      render json: @survey
+    else
+      render json: @survey.errors, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -67,14 +67,6 @@ class SurveysController < ApplicationController
     end
   end
 
-  def update
-    if @survey.update(params.require(:survey).permit(:created_at))
-      render json: @survey
-    else
-      render json: @survey.errors, status: :unprocessable_entity
-    end
-  end
-
   # DELETE /surveys/1
   def destroy
     @survey.destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,9 +72,13 @@ class User < ApplicationRecord
   end
 
   def get_feedback_message
-    if (self.streak % 3 == 0)
-      index = (self.streak / 3).to_i + 1
-      return Message.where.not(feedback_message: [nil, ""]).order("id ASC")[index]
+    if self.streak % 3 == 0 || self.streak == 1
+      index = (self.streak / 3).to_i
+      message = Message.where.not(feedback_message: [nil, ""]).order("id ASC")[index]
+      return message.feedback_message
+    elsif self.streak == 112
+      message = Message.where.not(feedback_message: [nil, ""]).order("id ASC").last
+      return message.feedback_message
     else
       return nil
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
 
   # Index name for a users is now:
   # classname_environment[if survey user has group, _groupmanagergroupname]
-  # It has been overriden searchkick's class that sends data to elaticsearch, 
+  # It has been overriden #searchkick's class that sends data to elaticsearch, 
   # such that the index name is now defined by the model that is being 
   # evaluated using the function 'index_pattern_name'
   def index_pattern_name
@@ -86,7 +86,7 @@ class User < ApplicationRecord
   end
 
   def get_feedback_message
-    if self.streak % 3 == 0 || self.streak == 1
+    if (self.streak % 3 == 0 || self.streak == 1) && self.streak < 112
       index = (self.streak / 3).to_i
       message = Message.where.not(feedback_message: [nil, ""]).order("id ASC")[index]
       return message.feedback_message
@@ -94,7 +94,9 @@ class User < ApplicationRecord
       message = Message.where.not(feedback_message: [nil, ""]).order("id ASC").last
       return message.feedback_message
     else
-      return nil
+      index = self.streak % 4
+      message = Message.where.not(feedback_message: [nil, ""]).order("id DESC")[index]
+      return message.feedback_message
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,4 +60,23 @@ class User < ApplicationRecord
     elastic_data[:household_count] = self.households.count
     return elastic_data 
   end
+
+  def update_streak(survey)
+    last_survey = Survey.filter_by_user(self.id).order("id DESC").offset(1).first
+    if last_survey.created_at.day == survey.created_at.prev_day.day
+      self.streak += 1
+    else
+      self.streak = 1
+    end
+    self.update_attribute(:streak, self.streak)
+  end
+
+  def get_feedback_message
+    if (self.streak % 3 == 0)
+      index = (self.streak / 3).to_i + 1
+      return Message.where.not(feedback_message: [nil, ""]).order("id ASC")[index]
+    else
+      return nil
+    end
+  end
 end

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,4 +1,4 @@
 class MessageSerializer < ActiveModel::Serializer
-  attributes :id, :title, :warning_message, :go_to_hospital_message
+  attributes :id, :title, :warning_message, :go_to_hospital_message, :feedback_message
   belongs_to :syndrome
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :picture, :app_id, :city, :state, :identification_code, :group_id, :school_unit_id, :risk_group, :group
+  attributes :id, :user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :picture, :app_id, :city, :state, :identification_code, :group_id, :school_unit_id, :risk_group, :group, :streak
 
   belongs_to :app do
     link(:app) {app_url(object.app.id)}

--- a/db/migrate/20200624190816_create_messages.rb
+++ b/db/migrate/20200624190816_create_messages.rb
@@ -4,6 +4,7 @@ class CreateMessages < ActiveRecord::Migration[5.2]
       t.string :title
       t.text :warning_message
       t.text :go_to_hospital_message
+      t.text :feedback_message
       t.references :syndrome, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20200905020549_add_streak_to_user.rb
+++ b/db/migrate/20200905020549_add_streak_to_user.rb
@@ -1,0 +1,5 @@
+class AddStreakToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :streak, :integer, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_022156) do
+ActiveRecord::Schema.define(version: 2020_09_05_020549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_12_152255) do
+ActiveRecord::Schema.define(version: 2020_09_05_020549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2020_08_12_152255) do
     t.string "title"
     t.text "warning_message"
     t.text "go_to_hospital_message"
+    t.text "feedback_message"
     t.bigint "syndrome_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -288,6 +289,7 @@ ActiveRecord::Schema.define(version: 2020_08_12_152255) do
     t.boolean "risk_group"
     t.string "aux_code"
     t.bigint "school_unit_id"
+    t.integer "streak", default: 1
     t.index ["app_id"], name: "index_users_on_app_id"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
**Descrição**<br>
Esse PR cria a lógica na API das mensagens de feedback para usuários que reportarem em dias consecutivos. Há uma mensagem para cada 3 dias, feita pela equipe de comunicação que pode ser encontrada [aqui](https://docs.google.com/document/d/19iZQq1naWkccxP9KuHeaEyDnhlcj-_IeV4mccjFzTRM/edit), que será cadastrada no banco de dados após as mudanças subirem para produção. Para acessar/criar/editar uma mensagem de feedback pode ser usado as rotas já existentes na API para a model mensagem. Para criar basta apenas criar com o atributo "feedback_message" dentro de "message" no JSON. 
Foi editado a model do usuário para que seja possível guardar os dias consecutivos reportados através do atributo STREAK com valor padrão igual a 1 para todos os usuários inicialmente. Esse valor pode aumentar, mas caso o usuário perca sua streak ela retornará a 1 novamente. Dentro da model foram criados dois métodos novos, um para realizar o update da streak do usuário dependendo das datas do último report e do report atual. Outro para retornar a mensagem de feedback apropriada para a streak. <br>

