### PR TITLE
Alteração de formato de dados survey enviados para elasticsearch

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -78,7 +78,9 @@ class Survey < ApplicationRecord
     # Add user group. If group is not present and school unit is, add school unit description
     if !user.group.nil?
       elastic_data[:group] = user.group.get_path(string_only=true, labeled=false).join('/') 
-    else 
+    elsif !user.school_unit_id.nil?
+      elastic_data[:group] = SchoolUnit.find(user.school_unit_id).description
+    else
       elastic_data[:group] = nil 
     end
     


### PR DESCRIPTION
**Descrição**<br>

**Os seguintes campos serão adicionados**
- `user_country`
- `user_city`
- `user_state`
- `birthdate`
- `risk_group`

**Os seguintes campos serão alterados:**
- `latitude`: Com distancias aleatórias de até 30 metros do seu local original, por questões de integridade de privacidade.
- `longitude`: Com distancias aleatórias de até 30 metros do seu local original, por questões de integridade de privacidade.
- `group`: diversas confusões foram causadas pela relação entre essa campo e `group`, portanto os dados do antigo `enrolled_in` vão aparecer aqui agora, caso `group` seja nulo.

**Os seguintes campos serão removidos:**
- `enrolled_in`: diversas confusões foram causadas pela relação entre essa campo e `group`, portanto os dados antigamente aqui vão para `group`, caso `group` seja nulo, e esse campo será excluído.

Conserta issue #166 (exceto pelo reindex na base em prod)

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [x] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
