### PR TITLE
Add household name to csv data and increase response timeout range

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -130,11 +130,9 @@ class Survey < ApplicationRecord
     data[:household_identification_code] = nil
     data[:household_created_at] = nil
     data[:household_name] = nil
-    if self.household_id != nil
-      data[:household_identification_code] = self.household.identification_code
-      data[:household_created_at] = self.household.created_at
-      data[:household_name] = self.household.description
-    end
+    data[:household_identification_code] = self.household.identification_code if self.household
+    data[:household_created_at] = self.household.created_at if self.household
+    data[:household_name] = self.household.description if self.household
     data
   end
   

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -129,9 +129,11 @@ class Survey < ApplicationRecord
     data[:identification_code] = self.user.identification_code
     data[:household_identification_code] = nil
     data[:household_created_at] = nil
+    data[:household_name] = nil
     if self.household_id != nil
       data[:household_identification_code] = self.household.identification_code
       data[:household_created_at] = self.household.created_at
+      data[:household_name] = self.household.description
     end
     data
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,6 +7,11 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 threads threads_count, threads_count
 
+# Requests can take up to five minutes to respond
+# This is set so it's possible can load all surveys 
+# csv data on surveys_controller#surveys_to_csv route
+worker_timeout (5*60)
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
 port        ENV.fetch("PORT") { 3000 }


### PR DESCRIPTION
**Descrição**<br>

Adiciona o nome do household no novo feature de surveys em csv e aumenta o tempo de timeout do rails para impedir que a response ê timeout antes de carregar todos os dados necessários.

*100,000 surveys do csv = 1 minuto de processemento*

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [x] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
