### PR TITLE
Melhora a feature de gamificação

### DIFF
--- a/app/controllers/households_controller.rb
+++ b/app/controllers/households_controller.rb
@@ -20,7 +20,7 @@ class HouseholdsController < ApplicationController
     @household.user_id = @user.id
 
     if @household.save
-      @user.reindex
+      # @user.reindex
       render json: @household, status: :created, location: user_household_path(:id => @user)
     else
       render json: @household.errors, status: :unprocessable_entity
@@ -65,7 +65,8 @@ class HouseholdsController < ApplicationController
         :school_unit_id, 
         :identification_code, 
         :risk_group,
-        :group_id
+        :group_id,
+        :streak
       )
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -46,6 +46,6 @@ class MessagesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def message_params
-      params.require(:message).permit(:title, :warning_message, :go_to_hospital_message, :syndrome_id, :symptom_id, :feedback_message)
+      params.require(:message).permit(:title, :warning_message, :go_to_hospital_message, :syndrome_id, :symptom_id, :feedback_message, :day)
     end
 end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -57,9 +57,9 @@ class SurveysController < ApplicationController
       if @survey.save
         @user.update_streak(@survey)
         if @survey.symptom.length > 0
-          render json: { survey: @survey, feedback_message: @user.get_feedback_message, messages: @survey.get_message(@user) }, status: :created, location: user_survey_path(:id => @user)
+          render json: { survey: @survey, feedback_message: @user.get_feedback_message(@survey), messages: @survey.get_message(@user) }, status: :created, location: user_survey_path(:id => @user)
         else
-          render json: { survey: @survey, feedback_message: @user.get_feedback_message }, status: :created, location: user_survey_path(:id => @user)
+          render json: { survey: @survey, feedback_message: @user.get_feedback_message(@survey) }, status: :created, location: user_survey_path(:id => @user)
         end
       else
         render json: @survey.errors, status: :unprocessable_entity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,10 +91,11 @@ class User < ApplicationRecord
   end
 
   def get_feedback_message
-    message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", self.streak)
-    if message.empty?
-      index = self.streak % 4
-      message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", -1)[index]
+    message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", self.streak).first
+    if !message
+      message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", -1)
+      index = self.streak % message.size
+      message = message[index]
     end
     return message.feedback_message
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,17 +91,11 @@ class User < ApplicationRecord
   end
 
   def get_feedback_message
-    if (self.streak % 3 == 0 || self.streak == 1) && self.streak < 112
-      index = (self.streak / 3).to_i
-      message = Message.where.not(feedback_message: [nil, ""]).order("id ASC")[index]
-      return message.feedback_message
-    elsif self.streak == 112
-      message = Message.where.not(feedback_message: [nil, ""]).order("id ASC").last
-      return message.feedback_message
-    else
+    message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", self.streak)
+    if message.empty?
       index = self.streak % 4
-      message = Message.where.not(feedback_message: [nil, ""]).order("id DESC")[index]
-      return message.feedback_message
+      message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", -1)[index]
     end
+    return message.feedback_message
   end
 end

--- a/app/serializers/household_serializer.rb
+++ b/app/serializers/household_serializer.rb
@@ -1,5 +1,7 @@
 class HouseholdSerializer < ActiveModel::Serializer
-  attributes :id, :description, :birthdate, :country, :gender, :race, :kinship, :picture, :school_unit_id, :identification_code, :group, :group_id, :risk_group, :created_at
+  attributes :id, :description, :birthdate, :country, :gender, :race, :kinship,
+             :picture, :school_unit_id, :identification_code, :group, :group_id,
+             :risk_group, :created_at, :streak
   has_one :user
 
   def group

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,4 +1,4 @@
 class MessageSerializer < ActiveModel::Serializer
-  attributes :id, :title, :warning_message, :go_to_hospital_message, :feedback_message
+  attributes :id, :title, :warning_message, :go_to_hospital_message, :feedback_message, :day
   belongs_to :syndrome
 end

--- a/db/migrate/20201020203908_add_day_to_messages.rb
+++ b/db/migrate/20201020203908_add_day_to_messages.rb
@@ -1,0 +1,5 @@
+class AddDayToMessages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :messages, :day, :integer, :default => -1
+  end
+end

--- a/db/migrate/20201021181235_add_streak_to_household.rb
+++ b/db/migrate/20201021181235_add_streak_to_household.rb
@@ -1,0 +1,5 @@
+class AddStreakToHousehold < ActiveRecord::Migration[5.2]
+  def change
+    add_column :households, :streak, :integer, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_013233) do
+ActiveRecord::Schema.define(version: 2020_10_21_181235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_013233) do
     t.string "identification_code"
     t.boolean "risk_group"
     t.integer "group_id"
+    t.integer "streak", default: 0
     t.index ["deleted_at"], name: "index_households_on_deleted_at"
     t.index ["school_unit_id"], name: "index_households_on_school_unit_id"
     t.index ["user_id"], name: "index_households_on_user_id"
@@ -144,11 +145,12 @@ ActiveRecord::Schema.define(version: 2020_09_24_013233) do
     t.string "title"
     t.text "warning_message"
     t.text "go_to_hospital_message"
-    t.text "feedback_message"
     t.bigint "syndrome_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "symptom_id"
+    t.string "feedback_message"
+    t.integer "day", default: -1
     t.index ["symptom_id"], name: "index_messages_on_symptom_id"
     t.index ["syndrome_id"], name: "index_messages_on_syndrome_id"
   end


### PR DESCRIPTION
**Descrição**<br>
Este PR melhora a gamificação do app. Agora não é mais necessário salvar as mensagens de feedback em ordem no banco. É possível salvar elas com um novo atributo "day"(inteiro) que significa em qual dia ela irá aparecer. É necessário se atentar para que não haja duas mensagens para o mesmo dia, pois se houver irá retornar apenas a primeira mensagem.<br>
**Exemplo**
Caso eu queira criar uma mensagem que apareça no décimo dia consecutivo de report do usuário eu preciso criar a seguinte mensagem:
{ "message": { "feedback_message": "Conteudo da mensagem aqui", "day": 10 } } 
Caso eu queira criar uma mensagem padrão:
{ "message": { "feedback_message": "Conteudo da mensagem aqui", "day": -1 } } . Day = -1 significa que essa mensagem é uma mensagem padrão e irá ser escolhida nos dias em que não houver mensagens específicas para esse dia.

**Como testar**
Para testar verifique qual o streak do seu usuário no banco usando o GET. Após isso crie mensagens para os dias consecutivos a esse número e crie mensagens padrões. Após isso faça o report e veja se a mensagem de feedback retornada é a mensagem de feedback esperada.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
