### PR TITLE
Remove offset from latitude and longitude of surveys on elasticsearch

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -84,7 +84,7 @@ class Survey < ApplicationRecord
     end
 
     # Get object data as hash off of json
-    elastic_data = self.as_json(except: [:updated_at, :latitude, :longitude]) 
+    elastic_data = self.as_json(except: [:updated_at]) 
     
     # Add user group. If group is not present and school unit is, add school unit description
     if !user.group.nil?
@@ -99,11 +99,6 @@ class Survey < ApplicationRecord
     Symptom.all.each do |symptom|
       elastic_data[symptom.description] = self.symptom.include? symptom.description
     end
-    
-    # Add latitude and longitude
-    lat_long = get_anonymous_latitude_longitude
-    elastic_data["latitude"]  = lat_long[:latitude]
-    elastic_data["longitude"] = lat_long[:longitude]
     
     # Add user's city, state, country, 
     # birthdate, if she is part of the risk group for COVID,
@@ -136,6 +131,9 @@ class Survey < ApplicationRecord
     data
   end
   
+  # this function will not be used anymore, because the offset of
+  # the location is not wanted anymore, but it will be here if someone
+  # needs one day
   def get_anonymous_latitude_longitude
     # This offsets a survey positioning randomly by, at most, 50 meters, so as to "anonymize" data
     if self.latitude == nil || self.longitude == nil


### PR DESCRIPTION
**Descrição**<br
Esse PR remove a variação da latitude e longitude dos surveys no elasticsearch, assim também manda esses dois dados como foram recebidos, sem limitações de decimal etc.<br>
