### PR TITLE
Adds the app_id to syndromes

### DIFF
--- a/app/controllers/syndromes_controller.rb
+++ b/app/controllers/syndromes_controller.rb
@@ -6,7 +6,15 @@ class SyndromesController < ApplicationController
 
   # GET /syndromes
   def index
-    @syndromes = Syndrome.all
+    if current_user.nil? && current_manager.nil?
+      @user = current_admin
+    elsif current_admin.nil? && current_user.nil?
+      @user = current_manager
+    else
+      @user = current_user
+    end
+    
+    @syndromes = Syndrome.filter_syndrome_by_app_id(@user.app_id)
 
     render json: @syndromes
   end
@@ -100,7 +108,8 @@ class SyndromesController < ApplicationController
     def syndrome_params
       params.require(:syndrome).permit(
         :description,
-        :details, 
+        :details,
+        :app_id,
         :symptom => [[:description,:code,:percentage,:details,:priority,:app_id]],
         message_attributes: [  :title, :warning_message, :go_to_hospital_message ]
       )

--- a/app/models/syndrome.rb
+++ b/app/models/syndrome.rb
@@ -1,11 +1,15 @@
 class Syndrome < ApplicationRecord
+  belongs_to :app
   if !Rails.env.test?
     searchkick
   end
+
 
   has_one :message, dependent: :destroy
   accepts_nested_attributes_for :message
 
   has_many :syndrome_symptom_percentage, :class_name => 'SyndromeSymptomPercentage', dependent: :destroy
-  has_many :symptoms, :through => :syndrome_symptom_percentage 
+  has_many :symptoms, :through => :syndrome_symptom_percentage
+
+  scope :filter_syndrome_by_app_id, ->(current_user_app_id) { where(app_id: current_user_app_id) }
 end

--- a/app/serializers/syndrome_serializer.rb
+++ b/app/serializers/syndrome_serializer.rb
@@ -1,5 +1,5 @@
 class SyndromeSerializer < ActiveModel::Serializer
-  attributes :id, :description, :details
+  attributes :id, :description, :details, :app
 
   has_one :message
   has_many :symptoms

--- a/db/migrate/20201118225337_add_app_id_to_syndromes.rb
+++ b/db/migrate/20201118225337_add_app_id_to_syndromes.rb
@@ -1,0 +1,5 @@
+class AddAppIdToSyndromes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :syndromes, :app_id, :bigint, :default => 1, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_10_211235) do
+ActiveRecord::Schema.define(version: 2020_11_18_225337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,11 +32,9 @@ ActiveRecord::Schema.define(version: 2020_11_10_211235) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "app_id"
-    t.bigint "permission_id"
     t.string "aux_code"
     t.index ["app_id"], name: "index_admins_on_app_id"
     t.index ["email"], name: "index_admins_on_email", unique: true
-    t.index ["permission_id"], name: "index_admins_on_permission_id"
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
@@ -85,11 +83,9 @@ ActiveRecord::Schema.define(version: 2020_11_10_211235) do
     t.boolean "require_id"
     t.integer "id_code_length"
     t.string "vigilance_email"
-    t.bigint "permission_id"
     t.string "aux_code"
     t.index ["app_id"], name: "index_group_managers_on_app_id"
     t.index ["email"], name: "index_group_managers_on_email", unique: true
-    t.index ["permission_id"], name: "index_group_managers_on_permission_id"
     t.index ["reset_password_token"], name: "index_group_managers_on_reset_password_token", unique: true
   end
 
@@ -169,7 +165,6 @@ ActiveRecord::Schema.define(version: 2020_11_10_211235) do
     t.string "title"
     t.text "warning_message"
     t.text "go_to_hospital_message"
-    t.text "feedback_message"
     t.bigint "syndrome_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -299,6 +294,7 @@ ActiveRecord::Schema.define(version: 2020_11_10_211235) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "message_id"
+    t.bigint "app_id", default: 1
     t.index ["message_id"], name: "index_syndromes_on_message_id"
   end
 
@@ -346,16 +342,13 @@ ActiveRecord::Schema.define(version: 2020_11_10_211235) do
   end
 
   add_foreign_key "admins", "apps"
-  add_foreign_key "admins", "permissions"
   add_foreign_key "contents", "apps"
   add_foreign_key "group_managers", "apps"
-  add_foreign_key "group_managers", "permissions"
   add_foreign_key "households", "school_units"
   add_foreign_key "households", "users"
   add_foreign_key "manager_group_permissions", "group_managers"
   add_foreign_key "manager_group_permissions", "groups"
   add_foreign_key "managers", "apps"
-  add_foreign_key "managers", "permissions"
   add_foreign_key "messages", "symptoms"
   add_foreign_key "messages", "syndromes"
   add_foreign_key "permissions", "admins"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_225337) do
+ActiveRecord::Schema.define(version: 2020_11_10_211235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -294,7 +294,6 @@ ActiveRecord::Schema.define(version: 2020_11_18_225337) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "message_id"
-    t.bigint "app_id", default: 1
     t.index ["message_id"], name: "index_syndromes_on_message_id"
   end
 


### PR DESCRIPTION
**Description**<br>
This PR adds the attribute app_id to syndromes. It was generated a migration to add, edited the controller to return only syndromes from the user's app_id and to create a syndrome with a specific app_id. It was also edited the serializer to return the app_id and the model to create the relationship between apps and syndromes. <br>


**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
