### PR TITLE
Conserta erro ao deletar gerente de instituição

### DIFF
--- a/app/controllers/group_managers_controller.rb
+++ b/app/controllers/group_managers_controller.rb
@@ -46,7 +46,6 @@ class GroupManagersController < ApplicationController
   end
 
   def destroy
-    ManagerGroupPermission.find(@group_manager.id)
     @group_manager.destroy!
   end
 


### PR DESCRIPTION
**Descrição**<br>
Este PR deleta uma linha no método destroy do group_manager controller. Esta linha retorna um erro quando o group_manager não possui um grupo. Como ela é apenas um find e não possui finalidade aparente e como é possível existir um group_manager sem grupo, a remoção desta linha se faz necessária.<br>

**Como testar**<br>
Delete um group_manager sem grupo.

**Resultados esperados**<br>
Group_manager precisa ser deletado.
