### PR TITLE
Query user by app_id

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -108,20 +108,33 @@ class UsersController < ApplicationController
   end
   
   def panel_list
-    if current_user.nil? && current_manager.nil?
+    if current_user.nil? && current_manager.nil? && current_group_manager.nil?
       @current_user = current_admin
-    elsif current_admin.nil? && current_user.nil?
+    elsif current_admin.nil? && current_user.nil? && current_group_manager.nil?
       @current_user = current_manager
+    elsif current_admin.nil? && current_user.nil? && current_manager.nil?
+      @current_user = current_group_manager
     else
       @current_user = current_user
     end
 
+    #Se o GROUP do USER possuir o GROUP_MANAGER_ID igual ao ID do GROUP_MANAGER ele é retornado
+
     if params[:email] 
       query_regex = "^" + params[:email]
-      @user =  User.user_by_app_id(@current_user.app_id).where('email ~* ?', query_regex)
+      if !current_group_manager.nil?
+        @groups = Group.where(group_manager_id: @current_user.id).ids
+        @user = User.where(group_id: @groups).where('email ~* ?', query_regex)
+      else
+        @user =  User.user_by_app_id(@current_user.app_id).where('email ~* ?', query_regex)
+      end
     else
-      #@user = User.all
-      @user = User.user_by_app_id(@current_user.app_id)
+      if !current_group_manager.nil?
+        @groups = Group.where(group_manager_id: @current_user.id).ids
+        @user = User.where(group_id: @groups)
+      else
+        @user = User.user_by_app_id(@current_user.app_id)
+      end 
     end
     paginate @user, per_page: 50
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -108,11 +108,20 @@ class UsersController < ApplicationController
   end
   
   def panel_list
+    if current_user.nil? && current_manager.nil?
+      @current_user = current_admin
+    elsif current_admin.nil? && current_user.nil?
+      @current_user = current_manager
+    else
+      @current_user = current_user
+    end
+
     if params[:email] 
       query_regex = "^" + params[:email]
-      @user =  User.where('email ~* ?', query_regex)
+      @user =  User.user_by_app_id(@current_user.app_id).where('email ~* ?', query_regex)
     else
-      @user = User.all
+      #@user = User.all
+      @user = User.user_by_app_id(@current_user.app_id)
     end
     paginate @user, per_page: 50
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  belongs_to :app
+  
   acts_as_paranoid
   if !Rails.env.test?
     searchkick
@@ -112,4 +114,6 @@ class User < ApplicationRecord
     end
     return message.feedback_message
   end
+
+  scope :user_by_app_id, ->(current_user_app_id) { where(app_id: current_user_app_id) }
 end


### PR DESCRIPTION
**Descrição**<br>
Esse PR resolve o problema da busca de usuários do Painel de Gerenciamento. Agora os usuários são retornados de acordo com o app_id do usuário logado no painel.

Resolve a issue [#155](https://github.com/proepidesenvolvimento/guardioes-web/issues/155) do repositório guardioes-web.

Para resolver completamente a issue citada acima, é necessário realizar adicionar um filtro para o caso de GroupManager, para a busca retornar apenas os usuários que são daquela instituição.