### PR TITLE
Conserta alguns pontos do pré registro

### DIFF
--- a/app/controllers/pre_registers_controller.rb
+++ b/app/controllers/pre_registers_controller.rb
@@ -15,10 +15,14 @@ class PreRegistersController < ApplicationController
 
   # POST /pre_registers
   def create
+    if !PreRegister.where("email = ?", pre_register_params[:email]).empty?
+      return render json: {errors: "Email already registered"}, status: 409
+    end
     @pre_register = PreRegister.new(pre_register_params)
 
+
     if @pre_register.save
-      PreRegisterMailer.new_group_request(@pre_register).deliver
+      PreRegisterMailer.analyze_email(@pre_register).deliver
       render json: @pre_register, status: :created, location: @pre_register
     else
       render json: @pre_register.errors, status: :unprocessable_entity

--- a/app/serializers/pre_register_serializer.rb
+++ b/app/serializers/pre_register_serializer.rb
@@ -1,4 +1,4 @@
 class PreRegisterSerializer < ActiveModel::Serializer
-  attributes :id, :cnpj, :phone, :organization_kind, :state, :company_name
+  attributes :id, :cnpj, :phone, :organization_kind, :state, :company_name, :email
   has_one :app
 end

--- a/db/migrate/20201202024839_add_index_to_pre_registers.rb
+++ b/db/migrate/20201202024839_add_index_to_pre_registers.rb
@@ -1,0 +1,5 @@
+class AddIndexToPreRegisters < ActiveRecord::Migration[5.2]
+  def change
+    add_index :pre_registers, :email, :unique => true
+  end
+end


### PR DESCRIPTION
**Descrição**<br>
Este PR retorna o email no GET de pre_register, deixa o email como único no banco de dados e modifica a função do mailer chamada pela api.<br>

**Como testar**<br>
1) Verifique se o email está sendo retornado ao dar um GET nos pre_registers
2) Tente criar um pre_register com um email já cadastrado e falhe
Obs.: não esqueça de rodar rails db:migrate

**Resultados esperados**<br>
1) O email precisa ser retornado
2) Não deve ser possível cadastrar um email já cadastrado

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
