### PR TITLE
Conserta erro ao criar um group_manager

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -15,7 +15,7 @@ class RegistrationController < Devise::RegistrationsController
     else
       build_resource(@sign_up_params)
       resource.save
-  
+
       render_resource(resource)
     end
   end
@@ -76,6 +76,7 @@ class RegistrationController < Devise::RegistrationsController
   def create_group_manager
     if params[:group_manager] && (current_admin || current_group_manager)
       @sign_up_params = sign_up_params
+      @sign_up_params[:vigilance_syndromes] = []
     else
       @sign_up_params = nil
     end
@@ -122,7 +123,8 @@ class RegistrationController < Devise::RegistrationsController
         :group_name,
         :require_id,
         :id_code_length,
-        :twitter
+        :twitter,
+        :vigilance_syndromes
       )
     else
       params.require(:manager).permit(


### PR DESCRIPTION
**Descrição**<br>
Como o atributo vigilance_syndromes do group_manager é default = "", ocorre um erro ao tentar salvar o objeto com esse valor, pois ele precisa ser como padrão = []. Então antes de salvar esse atributo é setado como [] para evitar esse erro. Não é possível criar um group_manager com valores setados para o atributo vigilance_syndromes, mas não é necessário atualmente, devido a página exclusiva para a vigilância ativa.  <br>

**Como testar**<br>
Tente criar um group_manager, tanto pelo insomnia/postman quanto pelo painel web.
Modifique as síndromes na página de vigilância ativa.

**Resultados esperados**<br>
É esperado que o group_manager seja criado corretamente.
É esperado que as síndromes sejam modificadas corretamente na página de vigilância ativa.
