### PR TITLE
Hide picture column to User and Household

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,9 @@ GEM
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
@@ -169,12 +172,16 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.1104)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.6)
     multi_json (1.14.1)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     naught (1.1.0)
     nio4r (2.3.1)
@@ -360,6 +367,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.0)
   faker
   geocoder
+  httparty
   jwt
   kaminari
   listen (>= 3.0.5, < 3.2)

--- a/app/serializers/household_serializer.rb
+++ b/app/serializers/household_serializer.rb
@@ -1,6 +1,6 @@
 class HouseholdSerializer < ActiveModel::Serializer
   attributes :id, :description, :birthdate, :country, :gender, :race, :kinship,
-             :picture, :identification_code, :group, :group_id,
+             :identification_code, :group, :group_id,
              :risk_group, :created_at, :streak
   has_one :user
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :picture, :city, :state, :identification_code, :group_id, :risk_group, :group, :streak, :policy_version, :created_at, :is_vigilance, :phone, :identification_code
+  attributes :id, :user_name, :email, :birthdate, :country, :gender, :race, :is_professional, :city, :state, :identification_code, :group_id, :risk_group, :group, :streak, :policy_version, :created_at, :is_vigilance, :phone
 
   belongs_to :app do
     link(:app) {app_url(object.app.id)}


### PR DESCRIPTION
**Descrição**<br>
Foi removido o atributo ```picture``` das serializers de User e Household porque não são mais utilizados pelo app.<br>

**Como testar**<br>
Rodar a api e dar get no User.

**Resultados esperados**<br>
Não possuir mais a coluna picture nos métodos GET.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
