### PR TITLE
Active outbreak before report case

### DIFF
--- a/app/controllers/group_managers_controller.rb
+++ b/app/controllers/group_managers_controller.rb
@@ -122,7 +122,7 @@ class GroupManagersController < ApplicationController
     end
 
     def update_params
-      params.require(:group_manager).permit(:email, :password, :name, :app_id, :group_name, :twitter, :require_id, :id_code_length, :vigilance_email, :username_godata, :password_godata)
+      params.require(:group_manager).permit(:email, :password, :name, :app_id, :group_name, :twitter, :require_id, :id_code_length, :vigilance_email, :username_godata, :password_godata, :userid_godata)
     end
 
     def check_authenticated_admin_or_manager

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -278,6 +278,11 @@ class Survey < ApplicationRecord
       caseData['questionnaireAnswers']['sintomas'] = [{'value': '1'}]
     end
 
+    #Active Outbreak before report case
+    uri = URI("#{ENV['GODATA_URL']}/api/users/#{group_manager.userid_godata}")
+    res = HTTParty.patch(uri, body: {activeOutbreakId: vigilance_syndrome[:surto_id]}, headers: { Authorization: 'Bearer ' + token})
+
+    #Report case
     uri = URI("#{ENV['GODATA_URL']}/api/outbreaks/#{vigilance_syndrome[:surto_id]}/cases")
     res = HTTParty.post(uri, body: caseData, headers: { Authorization: 'Bearer ' + token})
     end

--- a/db/migrate/20210227165442_add_go_data_user_id.rb
+++ b/db/migrate/20210227165442_add_go_data_user_id.rb
@@ -1,0 +1,5 @@
+class AddGoDataUserId < ActiveRecord::Migration[5.2]
+  def change
+    add_column :group_managers, :userid_godata, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_19_222415) do
+ActiveRecord::Schema.define(version: 2021_02_27_165442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_222415) do
     t.text "vigilance_syndromes", default: ""
     t.text "username_godata", default: ""
     t.text "password_godata", default: ""
+    t.text "userid_godata"
     t.index ["app_id"], name: "index_group_managers_on_app_id"
     t.index ["email"], name: "index_group_managers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_group_managers_on_reset_password_token", unique: true


### PR DESCRIPTION
Gera a migration para criar o campo para persistir o id do usuário godata.

Ativa o surto reportado toda vez antes de enviar um report para o godata