### PR TITLE
Add City Managers reset password

### DIFF
--- a/app/mailers/city_manager_mailer.rb
+++ b/app/mailers/city_manager_mailer.rb
@@ -1,0 +1,13 @@
+class CityManagerMailer < ApplicationMailer
+  default from: 'proepi.desenvolvimento@gmail.com'
+  layout 'mailer'
+
+  def reset_password_email(city_manager)
+    @city_manager = city_manager
+    email = mail()
+    email.from = 'ProEpi <proepi.desenvolvimento@gmail.com>'
+    email.to = city_manager.name + ' <' + city_manager.email + '>'
+    email.subject = '[Guardiões da Saúde] Redefinir Senha'
+    return email
+  end
+end

--- a/app/mailers/city_manager_mailer.rb
+++ b/app/mailers/city_manager_mailer.rb
@@ -1,13 +1,13 @@
-class CityManagerMailer < ApplicationMailer
-  default from: 'proepi.desenvolvimento@gmail.com'
-  layout 'mailer'
+class CityManagerMailer < ActionMailer::Base
+    default from: 'proepi.desenvolvimento@gmail.com'
+    layout 'mailer'
 
-  def reset_password_email(city_manager)
-    @city_manager = city_manager
-    email = mail()
-    email.from = 'ProEpi <proepi.desenvolvimento@gmail.com>'
-    email.to = city_manager.name + ' <' + city_manager.email + '>'
-    email.subject = '[Guardiões da Saúde] Redefinir Senha'
-    return email
-  end
+    def reset_password_email(city_manager)
+      @city_manager = city_manager
+      email = mail()
+      email.from = 'ProEpi <proepi.desenvolvimento@gmail.com>'
+      email.to = city_manager.name + ' <' + city_manager.email + '>'
+      email.subject = '[Guardiões da Saúde] Redefinir Senha'
+      return email
+    end
 end

--- a/app/views/city_manager_mailer/reset_password_email.html.erb
+++ b/app/views/city_manager_mailer/reset_password_email.html.erb
@@ -1,0 +1,9 @@
+<h1>Resgate de senha</h1>
+<p>Olá,</p>
+<p>Alguém requisitou o resgate da senha da sua conta (<%= @city_manager.email %>).</p>
+<p>Caso tenha sido você quem requisitou, use esse código para poder escolher uma nova senha:</h1>
+<h4>
+  <%= @city_manager.aux_code %>
+</h4>
+<p>Caso não tenha sido você, ignore este email.</p>
+<p>Sua senha <strong>não</strong> será alterada até que você use o código e cria uma nova senha.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,11 @@ Rails.application.routes.draw do
     }
 
   resources :city_managers
+  scope "/city_manager" do 
+    post "email_reset_password", to: "city_managers#email_reset_password"
+    post "show_reset_token", to: "city_managers#show_reset_token"
+    post "reset_password", to: "city_managers#reset_password"
+  end
 
   devise_for :city_managers,
     path: 'city_manager/',

--- a/db/migrate/20210312212517_add_aux_code_to_city_managers.rb
+++ b/db/migrate/20210312212517_add_aux_code_to_city_managers.rb
@@ -1,0 +1,5 @@
+class AddAuxCodeToCityManagers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :city_managers, :aux_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_203925) do
+ActiveRecord::Schema.define(version: 2021_03_12_212517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_203925) do
     t.bigint "app_id"
     t.string "name"
     t.string "city"
+    t.string "aux_code"
     t.index ["app_id"], name: "index_city_managers_on_app_id"
     t.index ["email"], name: "index_city_managers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_city_managers_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,11 +141,13 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.string "picture"
+    t.bigint "school_unit_id"
     t.string "identification_code"
     t.boolean "risk_group"
     t.integer "group_id"
     t.integer "streak", default: 0
     t.index ["deleted_at"], name: "index_households_on_deleted_at"
+    t.index ["school_unit_id"], name: "index_households_on_school_unit_id"
     t.index ["user_id"], name: "index_households_on_user_id"
   end
 
@@ -190,8 +192,8 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "symptom_id"
-    t.integer "day", default: -1
     t.string "feedback_message"
+    t.integer "day", default: -1
     t.index ["symptom_id"], name: "index_messages_on_symptom_id"
     t.index ["syndrome_id"], name: "index_messages_on_syndrome_id"
   end
@@ -226,6 +228,19 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.index ["email"], name: "index_pre_registers_on_email", unique: true
   end
 
+  create_table "public_hospitals", force: :cascade do |t|
+    t.string "description"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "kind"
+    t.string "phone"
+    t.text "details"
+    t.bigint "app_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_id"], name: "index_public_hospitals_on_app_id"
+  end
+
   create_table "rumors", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -233,6 +248,23 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.integer "confirmed_deaths"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "school_units", force: :cascade do |t|
+    t.string "code"
+    t.string "description"
+    t.string "address"
+    t.string "cep"
+    t.string "phone"
+    t.string "fax"
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "category"
+    t.string "zone"
+    t.string "level"
+    t.string "city"
+    t.string "state"
   end
 
   create_table "surveys", force: :cascade do |t|
@@ -322,22 +354,23 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.bigint "group_id"
     t.boolean "risk_group"
     t.string "aux_code"
+    t.bigint "school_unit_id"
     t.integer "policy_version", default: 1, null: false
     t.integer "streak", default: 0
     t.string "phone"
     t.boolean "is_vigilance", default: false
     t.index ["app_id"], name: "index_users_on_app_id"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["group_id"], name: "index_users_on_group_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["school_unit_id"], name: "index_users_on_school_unit_id"
   end
 
   add_foreign_key "admins", "apps"
   add_foreign_key "city_managers", "apps"
   add_foreign_key "contents", "apps"
   add_foreign_key "group_managers", "apps"
-  add_foreign_key "households", "users"
+  add_foreign_key "households", "school_units"
   add_foreign_key "manager_group_permissions", "group_managers"
   add_foreign_key "manager_group_permissions", "groups"
   add_foreign_key "managers", "apps"
@@ -347,9 +380,9 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
   add_foreign_key "permissions", "group_managers"
   add_foreign_key "permissions", "managers"
   add_foreign_key "pre_registers", "apps"
+  add_foreign_key "public_hospitals", "apps"
   add_foreign_key "surveys", "households"
   add_foreign_key "surveys", "syndromes"
-  add_foreign_key "surveys", "users"
   add_foreign_key "symptoms", "apps"
   add_foreign_key "symptoms", "messages"
   add_foreign_key "symptoms", "syndromes"
@@ -358,4 +391,5 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
   add_foreign_key "syndromes", "messages"
   add_foreign_key "users", "apps"
   add_foreign_key "users", "groups"
+  add_foreign_key "users", "school_units"
 end


### PR DESCRIPTION
**Descrição**<br>
Adiciona os métodos e rotas para recuperação de senha do City Manager. Esse PR também fecha a issue [#243](https://github.com/proepidesenvolvimento/guardioes-web/issues/243) do repo `guardioes-web`.<br>

**Como testar**<br>
Abra o painel do ```guardioes-web``` e escolha a opção de "Esqueci a senha" no login para digitar um email de City Manager e receber o código por email.

**Resultados esperados**<br>
Ser possível trocar a senha após ter esquecido.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
