### PR TITLE
Fix geocode gem and feedback_message on Survey model

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -34,7 +34,8 @@ class Survey < ApplicationRecord
   end
   
   reverse_geocoded_by :latitude, :longitude do |obj,results|
-    if geo = results.first
+    geo = results.first
+    if !geo.data['error']
       obj.city    = geo.city
       obj.country = geo.country
       obj.street  = geo.street

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,9 @@ class User < ApplicationRecord
     message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", obj.streak).first
     if !message
       message = Message.where.not(feedback_message: [nil, ""]).where("day = ?", -1)
+      if message.size == 0
+        return "Sua participação foi registrada."
+      end
       index = obj.streak % message.size
       message = message[index]
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,13 +141,11 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.string "picture"
-    t.bigint "school_unit_id"
     t.string "identification_code"
     t.boolean "risk_group"
     t.integer "group_id"
     t.integer "streak", default: 0
     t.index ["deleted_at"], name: "index_households_on_deleted_at"
-    t.index ["school_unit_id"], name: "index_households_on_school_unit_id"
     t.index ["user_id"], name: "index_households_on_user_id"
   end
 
@@ -228,19 +226,6 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.index ["email"], name: "index_pre_registers_on_email", unique: true
   end
 
-  create_table "public_hospitals", force: :cascade do |t|
-    t.string "description"
-    t.float "latitude"
-    t.float "longitude"
-    t.string "kind"
-    t.string "phone"
-    t.text "details"
-    t.bigint "app_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["app_id"], name: "index_public_hospitals_on_app_id"
-  end
-
   create_table "rumors", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -248,23 +233,6 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.integer "confirmed_deaths"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "school_units", force: :cascade do |t|
-    t.string "code"
-    t.string "description"
-    t.string "address"
-    t.string "cep"
-    t.string "phone"
-    t.string "fax"
-    t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "category"
-    t.string "zone"
-    t.string "level"
-    t.string "city"
-    t.string "state"
   end
 
   create_table "surveys", force: :cascade do |t|
@@ -354,23 +322,22 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
     t.bigint "group_id"
     t.boolean "risk_group"
     t.string "aux_code"
-    t.bigint "school_unit_id"
     t.integer "policy_version", default: 1, null: false
     t.integer "streak", default: 0
     t.string "phone"
     t.boolean "is_vigilance", default: false
     t.index ["app_id"], name: "index_users_on_app_id"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["group_id"], name: "index_users_on_group_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["school_unit_id"], name: "index_users_on_school_unit_id"
   end
 
   add_foreign_key "admins", "apps"
   add_foreign_key "city_managers", "apps"
   add_foreign_key "contents", "apps"
   add_foreign_key "group_managers", "apps"
-  add_foreign_key "households", "school_units"
+  add_foreign_key "households", "users"
   add_foreign_key "manager_group_permissions", "group_managers"
   add_foreign_key "manager_group_permissions", "groups"
   add_foreign_key "managers", "apps"
@@ -380,9 +347,9 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
   add_foreign_key "permissions", "group_managers"
   add_foreign_key "permissions", "managers"
   add_foreign_key "pre_registers", "apps"
-  add_foreign_key "public_hospitals", "apps"
   add_foreign_key "surveys", "households"
   add_foreign_key "surveys", "syndromes"
+  add_foreign_key "surveys", "users"
   add_foreign_key "symptoms", "apps"
   add_foreign_key "symptoms", "messages"
   add_foreign_key "symptoms", "syndromes"
@@ -391,5 +358,4 @@ ActiveRecord::Schema.define(version: 2021_03_12_212517) do
   add_foreign_key "syndromes", "messages"
   add_foreign_key "users", "apps"
   add_foreign_key "users", "groups"
-  add_foreign_key "users", "school_units"
 end


### PR DESCRIPTION
**Descrição**<br>
Corrige dois bugs possíveis na hora de criar uma survey: o primeiro é quando a gem geocode não consegue achar o local pela latitude e longitude, o segundo é quando não há nenhuma mensagem cadastrada de retorno.<br>

**Como testar**<br>
Enviar uma Survey com latitude: 0 e longitude: 0 não deve retornar erros.
Na falta de mensagem de feedback, uma padrão deve ser mostrada.

**Resultados esperados**<br>
Não retornar erro nos dois casos.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
