### PR TITLE
Mudando tipo da coluna require_id da tabela de group_managers de boolean para string

### DIFF
--- a/db/migrate/20210622214806_update_require_id.rb
+++ b/db/migrate/20210622214806_update_require_id.rb
@@ -1,0 +1,5 @@
+class UpdateRequireId < ActiveRecord::Migration[5.2]
+  def change
+    change_column :group_managers, :require_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_06_05_233453) do
-
+ActiveRecord::Schema.define(version: 2021_06_22_214806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,7 +150,7 @@ ActiveRecord::Schema.define(version: 2021_06_05_233453) do
     t.bigint "app_id"
     t.string "group_name"
     t.string "twitter"
-    t.boolean "require_id"
+    t.string "require_id"
     t.integer "id_code_length"
     t.string "vigilance_email"
     t.string "aux_code"


### PR DESCRIPTION
**Descrição**<br>
Foi mudado o tipo da coluna require_id da tabela de group_managers do banco de dados para poder permitir que o título do código de identificação no app fosse algo que os group_managers pudessem alterar.

**Como testar**<br>
Criar um group_managers com o require_id como string e verificar se foi salvo. Outro ponto é testar as rotas se o create/update também alteram corretamente. Para este ultímo pode ser usado o web ou mesmo o postman.

**Resultados esperados**<br>
A API deve ser capaz de guardar corretamente o valor em string, aceitar valor null e permiter alterações do tipo CRUD nas rotas. 

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
