### PR TITLE
Fix show Users for GroupManagerTeam

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,17 +110,7 @@ class UsersController < ApplicationController
   end
   
   def panel_list
-    if current_user.nil? && current_manager.nil? && current_city_manager.nil? && current_group_manager.nil?
-      @current_user = current_admin
-    elsif current_admin.nil? && current_user.nil? && current_city_manager.nil? && current_group_manager.nil?
-      @current_user = current_manager
-    elsif current_admin.nil? && current_user.nil? && current_manager.nil? && current_group_manager.nil?
-      @current_user = current_city_manager
-    elsif current_admin.nil? && current_user.nil? && current_city_manager.nil? && current_manager.nil?
-      @current_user = current_group_manager
-    else
-      @current_user = current_user
-    end
+    @current_user = current_devise_user
 
     if !current_city_manager.nil?
       if params[:email]
@@ -149,31 +139,30 @@ class UsersController < ApplicationController
       if !current_group_manager.nil?
         @groups = Group.where(group_manager_id: @current_user.id).ids
         @user = User.where(group_id: @groups)
+      elsif !current_group_manager_team.nil?
+        @groups = Group.where(group_manager_id: @current_user.group_manager_id).ids
+        @user = User.where(group_id: @groups)
       else
         @user = User.user_by_app_id(@current_user.app_id)
       end 
     end
+
     paginate @user, per_page: 50
   end
 
   def filtered_list
-    if current_user.nil? && current_manager.nil? && current_group_manager.nil?
-      @current_user = current_admin
-    elsif current_admin.nil? && current_user.nil? && current_group_manager.nil?
-      @current_user = current_manager
-    elsif current_admin.nil? && current_user.nil? && current_manager.nil?
-      @current_user = current_group_manager
-    else
-      @current_user = current_user
-    end
+    @current_user = current_devise_user
 
     if !current_group_manager.nil?
       @groups = Group.where(group_manager_id: @current_user.id).ids
       @user = User.where(group_id: @groups).ransack(params[:filters]).result
-    else
+    elsif !current_group_manager_team.nil?
+      @groups = Group.where(group_manager_id: @current_user.group_manager_id).ids
+      @user = User.where(group_id: @groups).ransack(params[:filters]).result
+    else 
       @user =  User.user_by_app_id(@current_user.app_id).ransack(params[:filters]).result
     end
-   
+
     paginate @user, per_page: 50
   end
 


### PR DESCRIPTION
**Descrição**<br>
Corrige os métodos `filtered_list` e `panel_list` na users_controller.rb para os GroupManagerTeams que não conseguiam ver os usuários pertencentes ao Grupo.<br>

**Como testar**<br>
Fazer login como GroupManagerTeam no Painel (`guardioes-web`);
Abrir o menu lateral 'Usuários';
Ver os usuários pertencentes a aquele grupo;
Utilizar a ferramenta de filtragem. 

**Resultados esperados**<br>
Retornar usuários da mesma instituição dos GroupManagerTeams

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
