### PR TITLE
Fix GroupManagerTeam Serializer

### DIFF
--- a/app/controllers/data_visualization_controller.rb
+++ b/app/controllers/data_visualization_controller.rb
@@ -56,7 +56,7 @@ class DataVisualizationController < ApplicationController
           when "vigilance"
             @dashboard_id = 18
         end
-        payload = {'params' => {'group' => @current_request_user.group_manager_id}, 'resource' => {'dashboard' => @dashboard_id}}
+        payload = {'params' => {'group' => @current_request_user.group_manager.id}, 'resource' => {'dashboard' => @dashboard_id}}
       when current_user
         puts "Common user"
     end

--- a/app/serializers/group_manager_team_serializer.rb
+++ b/app/serializers/group_manager_team_serializer.rb
@@ -1,5 +1,6 @@
 class GroupManagerTeamSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :group_manager_id, :app_id
+  attributes :id, :name, :email, :app_id
 
+  has_one :group_manager
   has_one :permission
 end


### PR DESCRIPTION
**Descrição**<br>
Adiciona relação `has_one: group_manager` no serializer do GroupManagerTeam para retornar o objeto do GroupManager inteiro na resposta. É necessário para o Painel.<br>

**Como testar**<br>
Dar GET na rota `/group_manager_teams` e ver o GroupManager correspondente ser retornado em cada GroupManagerTeam.

**Resultados esperados**<br>
Ver o objeto do GroupManager ser retornado em cada GroupManagerTeam.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
