### PR TITLE
Fix GroupManagerTeams permissions

### DIFF
--- a/app/controllers/data_visualizations_controller.rb
+++ b/app/controllers/data_visualizations_controller.rb
@@ -1,7 +1,9 @@
 require 'jwt'
 
-class DataVisualizationController < ApplicationController
+class DataVisualizationsController < ApplicationController
   before_action :set_current_request_user, only: [:metabase_urls]
+
+  authorize_resource :class => false
 
   def users_count
     return render json: User.count

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,7 +18,7 @@ class Ability
           can :update, App, :id => user.app_id
           can :update, [ CityManager ], :app_id => user.app_id
           can :update, Admin, :id => user.id
-          can :manage, [ Manager, GroupManager, Symptom, Syndrome, Content, User, Vaccine ]
+          can :manage, [ Manager, GroupManager, Symptom, Syndrome, Content, User, Vaccine, :data_visualization ]
         end
       when Manager
         can :read, convert_symbol(@permission.models_read)
@@ -28,17 +28,20 @@ class Ability
         can :update, Manager, :id => user.id
         can :destroy, convert_symbol(@permission.models_destroy)
         can :manage, convert_symbol(@permission.models_manage)
+        can :manage, [ :data_visualization ]
       when CityManager
         can :manage, User, :city => user.city
         can :manage, CityManager, :id => user.id
+        can :manage, [ :data_visualization ]
         cannot :destroy, CityManager, :id => user.id
       when GroupManager
+        can :update, [ Survey ]
+        can :update, GroupManager, :id => user.id
         can :manage, [ User, Group ]
         can :manage, [ Form ], :id => user.form_id
         can :manage, [ FormQuestion, FormAnswer ], :form_id => user.form_id
         can :manage, [ GroupManagerTeam ], :group_manager_id => user.id
-        can :update, [ Survey ]
-        can :update, GroupManager, :id => user.id
+        can :manage, [ :data_visualization ]
       when CityManager
         can :manage, User, :city => user.city
         can :manage, CityManager, :id => user.id
@@ -71,21 +74,23 @@ class Ability
   # Convert array of string to symbol ["content"] to [:content] e.g
   def convert_symbol(array)
     models = %i[]
-    array.each do |new_array|
-      if new_array == "symptom"
+    array.each do |model|
+      if model == "symptom"
         models << Symptom
-      elsif new_array == "syndrome"
+      elsif model == "syndrome"
         models << Syndrome
-      elsif new_array == "content"
+      elsif model == "content"
         models << Content
-      elsif new_array == "group"
-        models << Group
-      elsif new_array == "user"
-        models << User
-      elsif new_array == "citymanager"
-        models << CityManager
-      elsif new_array == "vaccine"
+      elsif model == "vaccine"
         models << Vaccine
+      elsif model == "dashboard"
+        models << :data_visualization
+      elsif model == "group"
+        models << Group
+      elsif model == "user"
+        models << User
+      elsif model == "citymanager"
+        models << CityManager
       end
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -85,8 +85,6 @@ class Ability
         models << Vaccine
       elsif model == "dashboard"
         models << :data_visualization
-      elsif model == "group"
-        models << Group
       elsif model == "user"
         models << User
       elsif model == "citymanager"

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -18,6 +18,7 @@ class Group < ApplicationRecord
   # Each group has [0..n] managers
   has_many :manager_group_permission, :class_name => 'ManagerGroupPermission'
   has_many :group_managers, :through => :manager_group_permission 
+  has_many :group_manager_teams, :through => :group_managers 
 
   # Each group has one parent (except for 'root_node', that's why optional is true)
   belongs_to :parent, class_name: "Group", optional: true

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -1,7 +1,9 @@
 class GroupSerializer < ActiveModel::Serializer
   attributes :id, :description, :children_label, :parent, :require_id, :id_code_length,
-             :group_manager, :form_id, :code, :address, :cep, :phone, :email,
+             :form_id, :code, :address, :cep, :phone, :email,
              :created_by, :updated_by
+
+  belongs_to :group_manager
 
   def parent
     if object.parent == nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,11 +18,11 @@ Rails.application.routes.draw do
   get "groups/:id/get_twitter", to: 'groups#get_twitter'
   resources :groups
 
-  get 'data_visualization/users_count', to: 'data_visualization#users_count'
-  get 'data_visualization/surveys_count', to: 'data_visualization#surveys_count'
-  get 'data_visualization/asymptomatic_surveys_count', to: 'data_visualization#asymptomatic_surveys_count'
-  get 'data_visualization/symptomatic_surveys_count', to: 'data_visualization#symptomatic_surveys_count'
-  post 'data_visualization/metabase_urls', to: 'data_visualization#metabase_urls'
+  get 'data_visualization/users_count', to: 'data_visualizations#users_count'
+  get 'data_visualization/surveys_count', to: 'data_visualizations#surveys_count'
+  get 'data_visualization/asymptomatic_surveys_count', to: 'data_visualizations#asymptomatic_surveys_count'
+  get 'data_visualization/symptomatic_surveys_count', to: 'data_visualizations#symptomatic_surveys_count'
+  post 'data_visualization/metabase_urls', to: 'data_visualizations#metabase_urls'
 
   get "dashboard", to: 'dashboard#index'
   


### PR DESCRIPTION
**Descrição**<br>
Corrige as permissões dos GroupManagerTeams para Groups e DataVisualizations.<br>

**Como testar**<br>
1. Abra o painel com o repo `guardioes-web` na branch `fix/groupManagerTeamsPermissions`;
2. Logue como uma Instituição que possua grupos;
3. Crie/edite dois GroupManagerTeams: Um com permissão para Grupos e Visualizações, outro com nenhuma das duas permissões;
4. Logue agora como Equipe de Instituição na primeira conta criada e teste as permissões nas abas de Grupos e Visualizações;
5. Logue agora como Equipe de Instituição na segunda conta criada e teste as mesmas permissões. 

**Resultados esperados**<br>
A primeira conta deve conseguir ver as Visualizações e gerenciar Grupos. A segunda conta não deve conseguir fazer nenhuma das duas ações.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
