### PR TITLE
Fix/reset password at first access

### DIFF
--- a/app/controllers/group_manager_teams_controller.rb
+++ b/app/controllers/group_manager_teams_controller.rb
@@ -97,6 +97,7 @@ class GroupManagerTeamsController < ApplicationController
         :password,
         :group_manager_id,
         :app_id,
+        :first_access,
         :permission => []
       )
     end

--- a/app/serializers/group_manager_serializer.rb
+++ b/app/serializers/group_manager_serializer.rb
@@ -2,7 +2,7 @@ class GroupManagerSerializer < ActiveModel::Serializer
   attributes :id, :name, :email, :group_name, :group_permissions,
              :vigilance_email, :twitter, :require_id, :id_code_length,
              :vigilance_syndromes, :url_godata, :username_godata, :password_godata,
-             :created_by, :updated_by, :app_id
+             :created_by, :updated_by, :app_id, :first_access
   has_many :group_manager_teams
   has_one :form
 

--- a/app/serializers/group_manager_team_serializer.rb
+++ b/app/serializers/group_manager_team_serializer.rb
@@ -1,5 +1,5 @@
 class GroupManagerTeamSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :app_id
+  attributes :id, :name, :email, :app_id, :first_access
 
   has_one :group_manager
   has_one :permission

--- a/db/migrate/20210802220538_add_first_access_to_group_manager_teams.rb
+++ b/db/migrate/20210802220538_add_first_access_to_group_manager_teams.rb
@@ -1,0 +1,5 @@
+class AddFirstAccessToGroupManagerTeams < ActiveRecord::Migration[5.2]
+  def change
+    add_column :group_manager_teams, :first_access, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_29_225603) do
+ActiveRecord::Schema.define(version: 2021_08_02_220538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 2021_07_29_225603) do
     t.string "created_by"
     t.string "updated_by"
     t.string "deleted_by"
+    t.boolean "first_access", default: true
     t.index ["app_id"], name: "index_group_manager_teams_on_app_id"
     t.index ["deleted_at"], name: "index_group_manager_teams_on_deleted_at"
     t.index ["email"], name: "index_group_manager_teams_on_email", unique: true


### PR DESCRIPTION
**Descrição**<br>
Foi pesquisado porque ocorre o bug de que alguns tipos de usuários não estavam sendo requisitados a alterarem a sua senha no primeiro acesso. O problema era nas serializer de group_manager e de group_manager_team, além disso este último não possuia o atributo first_access na sua tabela, então esse atributo foi adicionado e as alteração necessárias foram feitas nas controllers e serializers. 

**Como testar**<br>
Para testar basta criar um perfil de admin e entrar com ele. Feito isso crie cada tipo de usuário do painel e logue com cada um.

**Resultados esperados**<br>
É esperado que para cada primeiro login seja requisitado ao usuário que altere a sua senha. 

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
