### PR TITLE
Adicionar campo de limiar e atualizando cálculo do score de um survey

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -95,7 +95,7 @@ class SurveysController < ApplicationController
 
     date = DateTime.now.in_time_zone(Time.zone).beginning_of_day
     past_surveys = Survey.filter_by_user(current_user.id).where("created_at >= ?", date).where(household: @survey.household)
-
+    @survey.get_message(@user)
     if past_surveys.length == 2
       return render json: {errors: "The user already contributed two times today"}, status: :unprocessable_entity
     elsif past_surveys[0] && past_surveys[0].symptom[0] && @survey.symptom[0]

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -95,7 +95,6 @@ class SurveysController < ApplicationController
 
     date = DateTime.now.in_time_zone(Time.zone).beginning_of_day
     past_surveys = Survey.filter_by_user(current_user.id).where("created_at >= ?", date).where(household: @survey.household)
-    @survey.get_message(@user)
     if past_surveys.length == 2
       return render json: {errors: "The user already contributed two times today"}, status: :unprocessable_entity
     elsif past_surveys[0] && past_surveys[0].symptom[0] && @survey.symptom[0]

--- a/app/controllers/syndromes_controller.rb
+++ b/app/controllers/syndromes_controller.rb
@@ -107,6 +107,7 @@ class SyndromesController < ApplicationController
         :details,
         :days_period,
         :app_id,
+        :threshold_score,
         :symptom => [[ :description, :code, :percentage, :details, :priority, :app_id ]],
         message_attributes: [ :title, :warning_message, :go_to_hospital_message ]
       )

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -397,10 +397,12 @@ class Survey < ApplicationRecord
         syndrome: syndrome,
         likelyhood: get_syndrome_score(syndrome)
       }
+      if new_syndrome[:likelyhood] < syndrome.threshold_score
+        next
+      end
       syndrome_list.append(new_syndrome)
     end
     syndrome_list = syndrome_list.sort_by { |syndrome| syndrome[:likelyhood] }.reverse
-    syndrome_list = syndrome_list.select { |syndrome| syndrome[:likelyhood] > 0 }
     return syndrome_list[0..2]
   end
 

--- a/app/serializers/syndrome_serializer.rb
+++ b/app/serializers/syndrome_serializer.rb
@@ -1,5 +1,5 @@
 class SyndromeSerializer < ActiveModel::Serializer
-  attributes :id, :description, :details, :days_period, :created_by, :updated_by, :app
+  attributes :id, :description, :details, :days_period, :created_by, :updated_by, :app, :threshold_score
 
   has_one :message
   has_many :symptoms

--- a/db/migrate/20210811141836_add_threshold_score_to_syndromes.rb
+++ b/db/migrate/20210811141836_add_threshold_score_to_syndromes.rb
@@ -1,0 +1,5 @@
+class AddThresholdScoreToSyndromes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :syndromes, :threshold_score, :float
+  end
+end

--- a/db/migrate/20210811141836_add_threshold_score_to_syndromes.rb
+++ b/db/migrate/20210811141836_add_threshold_score_to_syndromes.rb
@@ -1,5 +1,5 @@
 class AddThresholdScoreToSyndromes < ActiveRecord::Migration[5.2]
   def change
-    add_column :syndromes, :threshold_score, :float
+    add_column :syndromes, :threshold_score, :float, default: 0.0, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_02_220538) do
+ActiveRecord::Schema.define(version: 2021_08_11_141836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -389,6 +389,7 @@ ActiveRecord::Schema.define(version: 2021_08_02_220538) do
     t.string "created_by"
     t.string "updated_by"
     t.string "deleted_by"
+    t.float "threshold_score"
     t.index ["message_id"], name: "index_syndromes_on_message_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -389,7 +389,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_141836) do
     t.string "created_by"
     t.string "updated_by"
     t.string "deleted_by"
-    t.float "threshold_score"
+    t.float "threshold_score", default: 0.0, null: false
     t.index ["message_id"], name: "index_syndromes_on_message_id"
   end
 


### PR DESCRIPTION
**Descrição**<br>
Esse pull request adapta o código para que a API receba e persista o valor de um limiar e use esse recurso para filtrar os surveys que tenham um score acima ou igual desse limite.

**Como testar**<br>
Crie/Atualize o valor do campo threshold_score de uma syndrome e verifique a persistência. Crie um survey e veja printando o score e o o threshold e confirmando a comparação. 

**Resultados esperados**<br>
é esperado que o sistema não retorne sindromes que tenham um score menor que o limiar com o survey que o usuário enviou.

**Checklist**
- [ ] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
