### PR TITLE
Fixing bug when a group is created

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,8 +22,8 @@ class GroupsController < ApplicationController
 
   # POST /groups
   def create
-    return render json: {error: 'Not enough permissions'}, status: :unprocessable_entity if !validate_manager_group_permissions
     @group = Group.new(group_params)
+    return render json: {error: 'Not enough permissions'}, status: :unprocessable_entity if !validate_manager_group_permissions
   
     if group_params[:parent_id] != nil
       if @group_manager


### PR DESCRIPTION
**Descrição**<br>
Foi trocado a ordem na função create da controller de groups. Agora o "@group" é gerado antes de chamar a função validate_group_manager_permissions.

**Como testar**<br>
Chame a rota create de groups normalmente e verifique se os groups são criado corretamente.


**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
