### PR TITLE
Adding offset to coordinates in surveyForMapSerializer

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -370,14 +370,14 @@ class Survey < ApplicationRecord
   # the location is not wanted anymore, but it will be here if someone
   # needs one day
   def get_anonymous_latitude_longitude
-    # This offsets a survey positioning randomly by, at most, 50 meters, so as to "anonymize" data
+    # This offsets a survey positioning randomly by, at most, 106 meters, and at least, 70 meters, so as to "anonymize" data
     if self.latitude == nil || self.longitude == nil
       return { latitude: nil, longitude: nil }
     end
     
     ret = {}
-    dx = 0.05 * rand() # latitude  offset in kilometers (up to 50 meters)
-    dy = 0.05 * rand() # longitude offset in kilometers (up to 50 meters)
+    dx = 0.1 * rand(0.5..0.75) # latitude  offset in kilometers (up to 75 meters)
+    dy = 0.1 * rand(0.5..0.75) # longitude offset in kilometers (up to 75 meters)
     r_earth = 6378     # Earth radius in kilometers
     pi = Math::PI
 

--- a/app/serializers/survey_for_map_serializer.rb
+++ b/app/serializers/survey_for_map_serializer.rb
@@ -1,3 +1,13 @@
 class SurveyForMapSerializer < ActiveModel::Serializer
     attributes :id, :latitude, :longitude, :symptom
+
+    def attributes(*args)
+        h = super(*args)
+        coordinates = Survey.new(h).get_anonymous_latitude_longitude
+        print h[:latitude].to_s, h[:longitude].to_s, '\n'
+        h[:latitude] = coordinates[:latitude]
+        h[:longitude] = coordinates[:longitude]
+        print h[:latitude].to_s, h[:longitude].to_s, '\n'
+        h
+    end
 end  

--- a/app/serializers/survey_for_map_serializer.rb
+++ b/app/serializers/survey_for_map_serializer.rb
@@ -4,10 +4,8 @@ class SurveyForMapSerializer < ActiveModel::Serializer
     def attributes(*args)
         h = super(*args)
         coordinates = Survey.new(h).get_anonymous_latitude_longitude
-        print h[:latitude].to_s, h[:longitude].to_s, '\n'
         h[:latitude] = coordinates[:latitude]
         h[:longitude] = coordinates[:longitude]
-        print h[:latitude].to_s, h[:longitude].to_s, '\n'
         h
     end
 end  


### PR DESCRIPTION
**Descrição**<br>
Foi alterada a função que calcula o offset das coordenadas de modo que não mostre a localização real do usuário no mapa. A função que calcula esse offset foi adicionada à serializaer SurveysForMapSerializer. 

**Como testar**<br>
Rode a aplicação, coloque prints na serializer SurveyForMapSerializer para comparar o antes e dps das coordenadas e por fim faça requisições na rota surveys/week para acionar os prints. Calculadoras de distância entre coordenadas na internet eralmente não dão a informação com a precisão necessária, portanto recomendo fazer um script em python para fazer esses calculos e verificar a distância.  

**Resultados esperados**<br>
É esperado que o offset em linha reta fique entre 70 e 106 metros aproximadamente e que as localização fornecidas sejam fornecidas com esse offset em relação às  originais. 

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
