### PR TITLE
Removing GroupManager permissions from response.

### DIFF
--- a/app/models/group_manager_team.rb
+++ b/app/models/group_manager_team.rb
@@ -6,13 +6,13 @@ class GroupManagerTeam < ApplicationRecord
 
   acts_as_paranoid
 
+  belongs_to :group_manager
+  belongs_to :app
+
   has_many :manager_group_permission, :class_name => 'ManagerGroupPermission', :through => :group_manager
   has_many :groups, :through => :manager_group_permission 
   has_one :permission, dependent: :destroy
   accepts_nested_attributes_for :permission
-
-  belongs_to :group_manager
-  belongs_to :app
 
   # Check if a group is permitted by recusively scaling group branch
   # confering if any of the groups are permitted on the way

--- a/app/serializers/group_manager_serializer.rb
+++ b/app/serializers/group_manager_serializer.rb
@@ -1,5 +1,5 @@
 class GroupManagerSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :group_name, :group_permissions,
+  attributes :id, :name, :email, :group_name,
              :vigilance_email, :twitter, :require_id, :id_code_length,
              :vigilance_syndromes, :url_godata, :username_godata, :password_godata,
              :created_by, :updated_by, :app_id, :first_access
@@ -14,13 +14,5 @@ class GroupManagerSerializer < ActiveModel::Serializer
       rescue
       end
     end
-  end
-
-  def group_permissions
-    list = []
-    object.groups.each do |g|
-      list << { group: g.get_path(string_only=true,labled=false).join('/'), id: g.id }
-    end
-    list
   end
 end

--- a/app/serializers/group_manager_serializer.rb
+++ b/app/serializers/group_manager_serializer.rb
@@ -1,5 +1,5 @@
 class GroupManagerSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :group_name,
+  attributes :id, :name, :email, :group_name, #:group_permissions,
              :vigilance_email, :twitter, :require_id, :id_code_length,
              :vigilance_syndromes, :url_godata, :username_godata, :password_godata,
              :created_by, :updated_by, :app_id, :first_access
@@ -14,5 +14,16 @@ class GroupManagerSerializer < ActiveModel::Serializer
       rescue
       end
     end
+  end
+
+  def group_permissions
+    list = []
+    object.groups.each do |g|
+      list << { 
+        group: g.get_path(string_only=true,labled=false).join('/'),
+        id: g.id 
+      }
+    end
+    list
   end
 end


### PR DESCRIPTION
**Descrição**<br>
Foi removido a parte em que adicionava as groupManagerPermissions na Serializer a fim de diminuir o tamanho em bytes da resposta que ia ao front. Resposta essa que grande demais pode gerar bugs na aplicação e então por isso esses dados foram retirados. 

**Como testar**<br>
Logue como GroupManager e verificar se o GroupManager  permission está na response. Outro teste é com relação as funcionalidades padrões que envolvem tanto os GroupManager teams e essa informação não está sendo usada em alguma parte da aplicação ou se essa ação de retirar possa ter causado algum outro bug. Para essa parte é necessário andar pela aplicaçaõ e testando alguns casos que podem gerar bugs.

**Resultados esperados**<br>
Espera-se que o site funcione normalmente, sem cair a página quando logue e que essa ação não gere nenhum outro bug.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);