### PR TITLE
Feature/addvigilance to gmt

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,10 +1,9 @@
 class SurveysController < ApplicationController
   before_action :authenticate_user!, except: %i[group_cases render_without_user all_surveys update limited_surveys surveys_to_csv]
-  before_action :authenticate_group_manager!, only: [:group_cases, :update]
   before_action :set_survey, only: [:show, :update, :destroy]
   before_action :set_user, only: [:index, :create]
 
-  authorize_resource only: [:update, :destroy]
+  authorize_resource only: [:update, :destroy, :group_cases, :update]
 
   @WEEK_SURVEY_CACHE_EXPIRATION = 15.minutes
   @LIMITED_SURVEY_CACHE_EXPIRATION = 15.minutes

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -19,7 +19,11 @@ class SurveysController < ApplicationController
   # GET /surveys/group_cases
   # GET group_manager related surveys with vigilance_syndromes
   def group_cases
-    @groups = Group.where(group_manager_id: current_group_manager.id).ids
+    if current_group_manager
+      @groups = Group.where(group_manager_id: current_group_manager.id).ids
+    else
+      @groups = Group.where(group_manager_id: current_group_manager_team.group_manager_id).ids
+    end
     @users = User.where(group_id: @groups).ids
     surveys = Survey.where(user_id: @users).where.not(syndrome_id: nil).order('surveys.created_at DESC')
     cases = surveys.clone.to_a

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,6 +46,7 @@ class Ability
         can :read, convert_symbol(@permission.models_read)
         can :create, convert_symbol(@permission.models_create)
         can :update, convert_symbol(@permission.models_update)
+        can :update, [ Survey ]
         can :update, GroupManagerTeam, :id => user.id
         can :destroy, convert_symbol(@permission.models_destroy)
         can :manage, convert_symbol(@permission.models_manage)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,7 +46,7 @@ class Ability
         can :read, convert_symbol(@permission.models_read)
         can :create, convert_symbol(@permission.models_create)
         can :update, convert_symbol(@permission.models_update)
-        can :update, [ Survey ]
+        can :manage, [ Survey ]
         can :update, GroupManagerTeam, :id => user.id
         can :destroy, convert_symbol(@permission.models_destroy)
         can :manage, convert_symbol(@permission.models_manage)


### PR DESCRIPTION
**Descrição**<br>
Foi adicionado permissões para os GroupManagerTeams para que eles tenham acesso aos Surveys. As syndromes não poderiam ser alteradas pois precisaria alterar no objeto de GroupManager.

**Como testar**<br>
Logue como GroupManagerTeam e teste as funcionalidades.
Logue como GroupManager e teste as funcionalidades.

**Resultados esperados**<br>
Que tanto o Groupmanager quanto o GroupManagerTeam consigam gerenciar os surves. Os GroupManagerTeam conseguem apenas visualizar as sindromes e o email da vigilância ativa. O resto das permissões continuam as mesmas para ambos os usuários.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
