### PR TITLE
Fix households

### DIFF
--- a/app/controllers/households_controller.rb
+++ b/app/controllers/households_controller.rb
@@ -22,7 +22,6 @@ class HouseholdsController < ApplicationController
     @household.user_id = @user.id
 
     if @household.save
-      @user.reindex
       render json: @household, status: :created, location: user_household_path(:id => @user)
     else
       render json: @household.errors, status: :unprocessable_entity


### PR DESCRIPTION
**Descrição**<br>
Corrige a criação de households. Havia um @user.reindex que era utilizado pelo elasticsearch, que foi descontinuado. Isso causava um status de erro na criação.<br>

**Como testar**<br>
Criar household pelo app usando essa branch na api local; ou
Criar household pela rota disponível no Postman.

**Resultados esperados**<br>
Ser possível criar households sem status de erro.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
