### PR TITLE
Fix survey HTTP status

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -81,13 +81,15 @@ class SurveysController < ApplicationController
 
     date = DateTime.now.in_time_zone(Time.zone).beginning_of_day
     past_surveys = Survey.filter_by_user(current_user.id).where("created_at >= ?", date).where(household: @survey.household)
+
     if past_surveys.length == 2
-      return render json: {errors: "The user already contributed two times today"}, status: :unprocessable_entity
+      return render json: {errors: "The user already contributed two times today"}, status: :already_reported
     elsif past_surveys[0] && past_surveys[0].symptom[0] && @survey.symptom[0]
-      return render json: {errors: "The user already contributed with this survey today"}, status: :unprocessable_entity
+      return render json: {errors: "The user already contributed with this survey today"}, status: :already_reported
     elsif past_surveys[0] && !past_surveys[0].symptom[0] && !@survey.symptom[0]
-      return render json: {errors: "The user already contributed with this survey today"}, status: :unprocessable_entity
+      return render json: {errors: "The user already contributed with this survey today"}, status: :already_reported
     end
+
     if @survey.save
       @user.update_streak(@survey)
       if @survey.symptom.length > 0


### PR DESCRIPTION
**Descrição**<br>
Corrige status HTTP ao já ter reportado Survey.<br>

**Como testar**<br>
1. Enviar Survey com usuário que não tenha reportado nenhuma vez (ver status 201)
2. Reportar Survey novamente (ver status 208 ao invés de 422)

**Resultados esperados**<br>
Status correto ao reportar mais de uma vez

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
