### PR TITLE
Add migration and relations for group_manager and content

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -5,8 +5,20 @@ class ContentsController < ApplicationController
   # GET /contents
   def index
     @user = current_devise_user
-    @contents = Content.user_country(@user.app_id)
 
+    case @user
+      when current_group_manager
+        @contents = Content.where(group_manager_id: @user.id)
+      when current_user
+        if @user.group && @user.group.group_manager
+          @contents = Content.where(group_manager_id: @user.group.group_manager.id)
+        else
+          @contents = Content.where(app_id: @user.app_id).where(group_manager_id: nil)
+        end
+      else
+        @contents = Content.where(app_id: @user.app_id).where(group_manager_id: nil)
+    end
+  
     render json: @contents
   end
 
@@ -52,7 +64,7 @@ class ContentsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def content_params
-      params.require(:content).permit(:title, :body, :icon, :content_type, :app_id, :source_link)
+      params.require(:content).permit(:title, :body, :icon, :content_type, :source_link, :group_manager_id, :app_id)
     end
 
     

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -41,7 +41,7 @@ class Ability
         can :manage, [ User, Group ]
         can :manage, [ Form ], :id => user.form_id
         can :manage, [ FormQuestion, FormAnswer ], :form_id => user.form_id
-        can :manage, [ GroupManagerTeam ], :group_manager_id => user.id
+        can :manage, [ Content, GroupManagerTeam ], :group_manager_id => user.id
         can :manage, [ Permission, :data_visualization ]
         cannot :manage, Permission, group_manager_team_id: nil
       when GroupManagerTeam

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,5 +1,6 @@
 class Content < ApplicationRecord
   belongs_to :app
+  belongs_to :group_manager, optional: true
 
   scope :admin_country, ->(current_admin_app) { where(app_id: current_admin_app) }
   scope :user_country, ->(current_user_app) { where(app_id: current_user_app) }

--- a/app/models/group_manager.rb
+++ b/app/models/group_manager.rb
@@ -8,6 +8,7 @@ class GroupManager < ApplicationRecord
 
   has_many :manager_group_permission, :class_name => 'ManagerGroupPermission', dependent: :delete_all
   has_many :groups, :through => :manager_group_permission 
+  has_many :contents, dependent: :destroy
   has_one :form, dependent: :destroy
   has_many :group_manager_teams, dependent: :destroy
   has_one :permission, dependent: :destroy

--- a/app/serializers/content_serializer.rb
+++ b/app/serializers/content_serializer.rb
@@ -1,3 +1,4 @@
 class ContentSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :icon, :content_type, :source_link, :created_at, :updated_at, :created_by, :updated_by
+  attributes :id, :title, :body, :icon, :content_type, :source_link, :group_manager_id, :app_id,
+             :created_at, :updated_at, :updated_by
 end

--- a/db/migrate/20220629023629_add_group_manager_to_contents.rb
+++ b/db/migrate/20220629023629_add_group_manager_to_contents.rb
@@ -1,0 +1,5 @@
+class AddGroupManagerToContents < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :contents, :group_manager, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_28_155059) do
+ActiveRecord::Schema.define(version: 2022_06_29_023629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,7 +94,9 @@ ActiveRecord::Schema.define(version: 2022_04_28_155059) do
     t.string "created_by"
     t.string "updated_by"
     t.string "deleted_by"
+    t.bigint "group_manager_id"
     t.index ["app_id"], name: "index_contents_on_app_id"
+    t.index ["group_manager_id"], name: "index_contents_on_group_manager_id"
   end
 
   create_table "crono_jobs", force: :cascade do |t|
@@ -487,6 +489,7 @@ ActiveRecord::Schema.define(version: 2022_04_28_155059) do
   add_foreign_key "categories", "apps"
   add_foreign_key "city_managers", "apps"
   add_foreign_key "contents", "apps"
+  add_foreign_key "contents", "group_managers"
   add_foreign_key "doses", "users"
   add_foreign_key "doses", "vaccines"
   add_foreign_key "form_answers", "form_options"


### PR DESCRIPTION
**Descrição**<br>
Foi adicionada a migração para adicionar o group_manager_id na tabela contents e criadas as relações nas models.<br>

**Como testar**<br>
Acessar o painel com a branch `add/gmContents` e testar com Administradores e Instituições a tela de Conteúdo.

**Resultados esperados**<br>
Contextos diferentes de conteúdos para Administradores e Instituição

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
