### PR TITLE
feat: add signal comments endpoints

### DIFF
--- a/app/controllers/flexible_answers_controller.rb
+++ b/app/controllers/flexible_answers_controller.rb
@@ -1,5 +1,5 @@
 class FlexibleAnswersController < ApplicationController
-  before_action :set_flexible_answer, only: [:show, :update, :destroy]
+  before_action :set_flexible_answer, only: [:show, :update, :destroy, :create_signal_comments, :signal_comments]
   authorize_resource
   # GET /flexible_answers
   NUMERO_SINAIS_RETORNADOS = 999
@@ -48,6 +48,18 @@ class FlexibleAnswersController < ApplicationController
   # DELETE /flexible_answers/1
   def destroy
     @flexible_answer.destroy
+  end
+
+  def signal_comments
+    messages = ExternalIntegrationService.get_messages(@flexible_answer.external_system_integration_id)
+    final_messages = messages || [].to_json
+    render json: final_messages
+  end
+
+  def create_signal_comments
+    response = ExternalIntegrationService.send_message(@flexible_answer.external_system_integration_id, params[:message])
+    response = JSON.parse(response) unless response.is_a?(Hash)
+    render json: response, status: :created
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,4 +179,6 @@ Rails.application.routes.draw do
 
     root to: "admin#index"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/flexible_answers/:id/signal_comments', to: 'flexible_answers#signal_comments'
+  post '/flexible_answers/:id/signal_comments', to: 'flexible_answers#create_signal_comments'
 end

--- a/spec/controllers/form_answers_controller_spec.rb
+++ b/spec/controllers/form_answers_controller_spec.rb
@@ -126,4 +126,24 @@ RSpec.describe FormAnswersController, type: :controller do
     end
   end
 
+  describe "GET #signal_comments" do
+    it "returns a success response" do
+      flexible_answer = FlexibleAnswer.create! valid_attributes
+      allow(ExternalIntegrationService).to receive(:get_messages).and_return([].to_json)
+
+      get :signal_comments, params: {id: flexible_answer.to_param}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST #create_signal_comments" do
+    it "returns a success response" do
+      flexible_answer = FlexibleAnswer.create! valid_attributes
+      allow(ExternalIntegrationService).to receive(:send_message).and_return({ message: "Test message" }.to_json)
+
+      post :create_signal_comments, params: {id: flexible_answer.to_param, message: "Test message"}, session: valid_session
+      expect(response).to have_http_status(:created)
+    end
+  end
+
 end


### PR DESCRIPTION
# Título: 

Adicionar integração com sistema externo para comentários em Flexible Answers

# Descrição:

Este PR implementa a funcionalidade de buscar e enviar comentários de/para um sistema externo a partir de uma Flexible Answer. As principais mudanças incluem:

## Novas ações no controller:
signal_comments: Busca comentários do sistema externo associado à Flexible Answer.
create_signal_comments: Envia um novo comentário para o sistema externo.
## Novas rotas:
GET /flexible_answers/:id/signal_comments
POST /flexible_answers/:id/signal_comments
## Testes unitários:
Verificam o funcionamento das novas ações e a integração com o ExternalIntegrationService.
## Utilização do ExternalIntegrationService:

Responsável por lidar com a comunicação com o sistema externo (busca e envio de mensagens).
## Motivação:

Permitir que os usuários interajam com comentários de um sistema externo diretamente a partir da aplicação, centralizando o gerenciamento da comunicação.

## Impacto:

Esta mudança afeta apenas o modelo FlexibleAnswer e suas interações. Nenhuma outra parte do sistema deve ser impactada.