### PR TITLE
fix: update to match app contract

### DIFF
--- a/app/serializers/flexible_answer_serializer.rb
+++ b/app/serializers/flexible_answer_serializer.rb
@@ -13,8 +13,13 @@ class FlexibleAnswerSerializer < ActiveModel::Serializer
       nil
     else
       external_system_integration_id = object.external_system_integration_id.to_s
-      signals_dict.fetch(external_system_integration_id,
-                         ExternalIntegrationService.default_event_value(external_system_integration_id))
+      result = signals_dict.fetch(external_system_integration_id,
+                                  ExternalIntegrationService.default_event_value(external_system_integration_id))
+      {
+        "_embedded": {
+          "signals": [result]
+        }
+      }
     end
   end
 end


### PR DESCRIPTION
## Descrição do Pull Request

### Mudanças Realizadas

Este PR modifica o arquivo `flexible_answer_serializer.rb` para ajustar a estrutura do retorno do método `signal`, encapsulando o resultado dentro de um objeto `_embedded` com uma chave `signals`.

### Objetivo

O objetivo desta alteração é garantir que o resultado do método `signal` esteja conforme o padrão esperado para respostas que incluem sinais de sistemas externos. Ao encapsular `result` dentro de um objeto `_embedded` com uma chave `signals`, o retorno passa a estar mais alinhado com as práticas de organização de dados estruturados, facilitando a integração e o consumo por parte de outros serviços e aplicações.

### Impacto

Esta mudança afeta a forma como os dados de sinais são serializados, potencialmente impactando qualquer integração que consuma esta API. É importante garantir que todos os consumidores do serviço estejam cientes desta alteração e possam tratar a nova estrutura de retorno corretamente.

### Testes

- Revisar e atualizar os testes unitários existentes para acomodar a nova estrutura de retorno.
- Adicionar novos testes, se necessário, para cobrir cenários onde a chave `_embedded` e `signals` são usadas.

### Considerações Finais

Esta modificação visa melhorar a consistência e a clareza da API, promovendo uma melhor prática de encapsulamento e organização dos dados retornados.
