### PR TITLE
Feature/aditional user info integration

### DIFF
--- a/app/services/external_integration_service.rb
+++ b/app/services/external_integration_service.rb
@@ -60,6 +60,10 @@ class ExternalIntegrationService
     Rails.logger.info "dados a serem enviados para o ephem #{event_data} #{event_data.class}"
 
     uri = URI("#{EPHEM_API_URL}#{API_PATH}/eventos")
+
+    if true
+      return { 'id' => 1 }
+    end
     res = HTTParty.post(uri, body: event_data.to_json, headers: HEADERS, debug_logger: Logger.new(STDOUT))
 
     parsed_response = handle_response(res)
@@ -106,6 +110,9 @@ class ExternalIntegrationService
       'eventoIntegracaoTemplate': DEFAULT_INTEGRATION_TEMPLE_ID,
       'userId': user.id,
       'userEmail': user.email,
+      'userName': user.user_name,
+      'userPhone': user.phone,
+      'userCountry': user.country,
       'eventSourceId': id,
       'eventSourceLocation': EMPTY_STRING,
       'eventSourceLocationId': DEFAULT_NOT_SELECTED_VALUE,

--- a/app/services/external_integration_service.rb
+++ b/app/services/external_integration_service.rb
@@ -60,10 +60,6 @@ class ExternalIntegrationService
     Rails.logger.info "dados a serem enviados para o ephem #{event_data} #{event_data.class}"
 
     uri = URI("#{EPHEM_API_URL}#{API_PATH}/eventos")
-
-    if true
-      return { 'id' => 1 }
-    end
     res = HTTParty.post(uri, body: event_data.to_json, headers: HEADERS, debug_logger: Logger.new(STDOUT))
 
     parsed_response = handle_response(res)

--- a/spec/services/external_integration_service_spec.rb
+++ b/spec/services/external_integration_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ExternalIntegrationService, type: :service do
   let(:flexible_answer) {
     double('FlexibleAnswer',
            id: 1,
-           user: double('User', id: 1, email: 'mock@mock.com'),
+           user: double('User', id: 1, email: 'mock@mock.com', user_name: 'User', phone: '9912345678', country: 'Brasil'),
            data: '{}',
            flexible_form_version: double('FlexibleFormVersion',
                                          extract_data_as_map_field_text: { 'data' => '{}' }))
@@ -105,6 +105,9 @@ RSpec.describe ExternalIntegrationService, type: :service do
         'eventoIntegracaoTemplate' => '/1',
         'userId' => 1,
         'userEmail' => 'mock@mock.com',
+        'userName' => 'User',
+        'userPhone' => '9912345678',
+        'userCountry' => 'Brasil',
         'eventSourceId' => 1,
         'eventSourceLocation' => '',
         'eventSourceLocationId' => 0,


### PR DESCRIPTION
## Descrição 
Neste pull request, foram adicionados novos campos ao método build_event_data na classe ExternalIntegrationService. Os campos adicionados são userName, userPhone e userCountry. Essas mudanças permitem que mais informações do usuário sejam enviadas durante a criação de um evento.  

## Como testar 

Para testar essas mudanças, você pode criar um novo evento usando o método create_event na classe ExternalIntegrationService. Certifique-se de que o objeto User que você está passando para o método tem os campos user_name, phone e country preenchidos. Após a criação do evento, você pode verificar se esses campos foram corretamente incluídos nos dados do evento.  

## Resultados esperados 

Os campos userName, userPhone e userCountry devem ser incluídos nos dados do evento quando um novo evento é criado. Esses campos devem corresponder aos valores correspondentes no objeto User que foi passado para o método create_event.  

## Checklist
<input></input>Código compila corretamente;
<input></input>Mudanças realizadas foram testadas e passaram nos testes;
<input></input>Feito por conta própria.
