### PR TITLE
feat: removendo regra

### DIFF
--- a/app/controllers/flexible_answers_controller.rb
+++ b/app/controllers/flexible_answers_controller.rb
@@ -28,7 +28,8 @@ class FlexibleAnswersController < ApplicationController
     @flexible_answer.user_id = current_user.id
 
     if @flexible_answer.save
-      if @flexible_answer.flexible_form.form_type == 'signal' && current_user.is_vbe
+      if @flexible_answer.flexible_form.form_type == 'signal'
+        # essa condicao foi removida: && current_user.is_vbe
         integration_service = ExternalIntegrationService.new(current_user)
         external_system_integration_id = integration_service.create_event(@flexible_answer)
 


### PR DESCRIPTION
**Descrição**<br>

Esta é uma mudança simples que remove a lógica que só permitia que os eventos de sinais dos usuários marcados com "is_vbe" sejam encaminhados para o Ephem via integração.

**Como testar**<br>

Após a remoção, qualquer usuário cadastrado que envie um sinal, este sinal será enviado para o Ephem (https://vbe.sds.unb.br/)

**Resultados esperados**<br>
Após a remoção, qualquer usuário cadastrado que envie um sinal, este sinal será enviado para o Ephem (https://vbe.sds.unb.br/)


**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [x] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
